### PR TITLE
Update for customizable RBAC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@propelauth/javascript",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@propelauth/javascript",
-      "version": "1.2.3",
+      "version": "1.2.5",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.13.16",

--- a/src/access_helper.test.js
+++ b/src/access_helper.test.js
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getAccessHelper } from "./access_helper"
+import { createOrgs, createOrgIdToOrgMemberInfo } from "./test_helper"
+ 
+it("access helper validate methods work", async () => {
+    const orgs = createOrgs(1)
+    const orgId = orgs[0].orgId
+    const fakeOrgId = "fakeOrgId"
+    const orgIdToOrgMemberInfo = createOrgIdToOrgMemberInfo(orgs)
+
+    const accessHelper = getAccessHelper(orgIdToOrgMemberInfo)
+
+    // org has the role of "Admin"
+    expect(accessHelper.isRole(orgId, "")).toBeFalsy()
+    expect(accessHelper.isRole(orgId, "Owner")).toBeFalsy()
+    expect(accessHelper.isRole(orgId, "Admin")).toBeTruthy()
+    expect(accessHelper.isRole(fakeOrgId, "Admin")).toBeFalsy()
+    expect(accessHelper.isRole(orgId, "Member")).toBeFalsy()
+
+    // org has the inherited roles of "Admin" and "Member"
+    expect(accessHelper.isAtLeastRole(orgId, "")).toBeFalsy()
+    expect(accessHelper.isAtLeastRole(orgId, "Owner")).toBeFalsy()
+    expect(accessHelper.isAtLeastRole(orgId, "Admin")).toBeTruthy()
+    expect(accessHelper.isAtLeastRole(fakeOrgId, "Admin")).toBeFalsy()
+    expect(accessHelper.isAtLeastRole(orgId, "Member")).toBeTruthy()
+
+    // org has the permissions "read" and "write"
+    expect(accessHelper.hasPermission(orgId, "")).toBeFalsy()
+    expect(accessHelper.hasPermission(orgId, "read")).toBeTruthy()
+    expect(accessHelper.hasPermission(fakeOrgId, "read")).toBeFalsy()
+    expect(accessHelper.hasPermission(orgId, "write")).toBeTruthy()
+    expect(accessHelper.hasPermission(orgId, "delete")).toBeFalsy()
+
+    // org has the permissions "read" and "write"
+    expect(accessHelper.hasAllPermissions(orgId, [])).toBeTruthy()
+    expect(accessHelper.hasAllPermissions(orgId, [""])).toBeFalsy()
+    expect(accessHelper.hasAllPermissions(orgId, ["read"])).toBeTruthy()
+    expect(accessHelper.hasAllPermissions(fakeOrgId, ["read"])).toBeFalsy()
+    expect(accessHelper.hasAllPermissions(orgId, ["write"])).toBeTruthy()
+    expect(accessHelper.hasAllPermissions(orgId, ["delete"])).toBeFalsy()
+    expect(accessHelper.hasAllPermissions(orgId, ["read", "write"])).toBeTruthy()
+    expect(accessHelper.hasAllPermissions(orgId, ["read", "delete"])).toBeFalsy()
+    expect(accessHelper.hasAllPermissions(orgId, ["write", "delete"])).toBeFalsy()
+    expect(accessHelper.hasAllPermissions(orgId, ["read", "write", "delete"])).toBeFalsy()
+})

--- a/src/access_helper.test.js
+++ b/src/access_helper.test.js
@@ -4,7 +4,7 @@
 import { getAccessHelper } from "./access_helper"
 import { createOrgs, createOrgIdToOrgMemberInfo } from "./test_helper"
  
-it("access helper validate methods work", async () => {
+it("accessHelper validate methods work", async () => {
     const orgs = createOrgs(1)
     const orgId = orgs[0].orgId
     const fakeOrgId = "fakeOrgId"
@@ -44,4 +44,29 @@ it("access helper validate methods work", async () => {
     expect(accessHelper.hasAllPermissions(orgId, ["read", "delete"])).toBeFalsy()
     expect(accessHelper.hasAllPermissions(orgId, ["write", "delete"])).toBeFalsy()
     expect(accessHelper.hasAllPermissions(orgId, ["read", "write", "delete"])).toBeFalsy()
+})
+
+it("accessHelper validate wrapper methods work", async () => {
+    const orgs = createOrgs(1)
+    const orgId = orgs[0].orgId
+    const fakeOrgId = "fakeOrgId"
+    const orgIdToOrgMemberInfo = createOrgIdToOrgMemberInfo(orgs)
+
+    const accessHelper = getAccessHelper(orgIdToOrgMemberInfo)
+    const accessHelperWrapper = accessHelper.getAccessHelperWithOrgId(orgId)
+    const accessHelperWrapperBad = accessHelper.getAccessHelperWithOrgId(fakeOrgId)
+
+    // we do most of the testing in the above test, this is just to make sure the wrapper methods work
+    expect(accessHelperWrapper.isRole("Admin")).toBeTruthy()
+    expect(accessHelperWrapper.isRole("Member")).toBeFalsy()
+    expect(accessHelperWrapper.isAtLeastRole("Owner")).toBeFalsy()
+    expect(accessHelperWrapper.isAtLeastRole("Member")).toBeTruthy()
+    expect(accessHelperWrapper.hasPermission("read")).toBeTruthy()
+    expect(accessHelperWrapper.hasPermission("delete")).toBeFalsy()
+    expect(accessHelperWrapper.hasAllPermissions(["read"])).toBeTruthy()
+    expect(accessHelperWrapper.hasAllPermissions(["delete"])).toBeFalsy()
+    expect(accessHelperWrapper.hasAllPermissions(["read", "write"])).toBeTruthy()
+    expect(accessHelperWrapper.hasAllPermissions(["read", "delete"])).toBeFalsy()
+    expect(accessHelperWrapper.hasAllPermissions(["read", "write", "delete"])).toBeFalsy()
+    expect(accessHelperWrapperBad.isRole("Admin")).toBeFalsy()
 })

--- a/src/access_helper.ts
+++ b/src/access_helper.ts
@@ -1,0 +1,44 @@
+import {OrgIdToOrgMemberInfo} from "./org";
+
+export type AccessHelper = {
+    isRole: (orgId: string, role: string) => boolean
+    isAtLeastRole: (orgId: string, role: string) => boolean
+    hasPermission: (orgId: string, permission: string) => boolean
+    hasAllPermissions: (orgId: string, permissions: string[]) => boolean
+}
+
+export function getAccessHelper(
+    orgIdToOrgMemberInfo: OrgIdToOrgMemberInfo,
+): AccessHelper {
+    return {
+        isRole(orgId: string, role: string): boolean {
+            const orgMemberInfo = orgIdToOrgMemberInfo[orgId]
+            if (orgMemberInfo === undefined) {
+                return false;
+            }
+            return orgMemberInfo.userAssignedRole === role
+        },
+        isAtLeastRole(orgId: string, role: string): boolean {
+            const orgMemberInfo = orgIdToOrgMemberInfo[orgId]
+            if (orgMemberInfo === undefined) {
+                return false;
+            }
+            return orgMemberInfo.userInheritedRolesPlusCurrentRole.includes(role)
+        },
+        hasPermission(orgId: string, permission: string): boolean {
+            const orgMemberInfo = orgIdToOrgMemberInfo[orgId]
+            if (orgMemberInfo === undefined) {
+                return false;
+            }
+            return orgMemberInfo.userPermissions.includes(permission)
+        },
+        hasAllPermissions(orgId: string, permissions: string[]): boolean {
+            const orgMemberInfo = orgIdToOrgMemberInfo[orgId]
+            if (orgMemberInfo === undefined) {
+                return false;
+            }
+            return permissions.every(permission => orgMemberInfo.userPermissions.includes(permission))
+        },
+        
+    }
+}

--- a/src/access_helper.ts
+++ b/src/access_helper.ts
@@ -5,40 +5,73 @@ export type AccessHelper = {
     isAtLeastRole: (orgId: string, role: string) => boolean
     hasPermission: (orgId: string, permission: string) => boolean
     hasAllPermissions: (orgId: string, permissions: string[]) => boolean
+    getAccessHelperWithOrgId: (orgId: string) => AccessHelperWithOrg
+}
+
+export type AccessHelperWithOrg = {
+    isRole: (role: string) => boolean
+    isAtLeastRole: (role: string) => boolean
+    hasPermission: (permission: string) => boolean
+    hasAllPermissions: (permissions: string[]) => boolean
 }
 
 export function getAccessHelper(
     orgIdToOrgMemberInfo: OrgIdToOrgMemberInfo,
 ): AccessHelper {
+    function isRole(orgId: string, role: string): boolean {
+        const orgMemberInfo = orgIdToOrgMemberInfo[orgId]
+        if (orgMemberInfo === undefined) {
+            return false;
+        }
+        return orgMemberInfo.userAssignedRole === role
+    }
+    
+    function isAtLeastRole(orgId: string, role: string): boolean {
+        const orgMemberInfo = orgIdToOrgMemberInfo[orgId]
+        if (orgMemberInfo === undefined) {
+            return false;
+        }
+        return orgMemberInfo.userInheritedRolesPlusCurrentRole.includes(role)
+    }
+
+    function hasPermission(orgId: string, permission: string): boolean {
+        const orgMemberInfo = orgIdToOrgMemberInfo[orgId]
+        if (orgMemberInfo === undefined) {
+            return false;
+        }
+        return orgMemberInfo.userPermissions.includes(permission)
+    }
+
+    function hasAllPermissions(orgId: string, permissions: string[]): boolean {
+        const orgMemberInfo = orgIdToOrgMemberInfo[orgId]
+        if (orgMemberInfo === undefined) {
+            return false;
+        }
+        return permissions.every(permission => orgMemberInfo.userPermissions.includes(permission))
+    }
+
+    function getAccessHelperWithOrgId(orgId: string): AccessHelperWithOrg {
+        return {
+            isRole(role: string): boolean {
+                return isRole(orgId, role)
+            },
+            isAtLeastRole(role: string): boolean {
+                return isAtLeastRole(orgId, role)
+            },
+            hasPermission(permission: string): boolean {
+                return hasPermission(orgId, permission)
+            },
+            hasAllPermissions(permissions: string[]): boolean {
+                return hasAllPermissions(orgId, permissions)
+            },
+        }
+    }
+    
     return {
-        isRole(orgId: string, role: string): boolean {
-            const orgMemberInfo = orgIdToOrgMemberInfo[orgId]
-            if (orgMemberInfo === undefined) {
-                return false;
-            }
-            return orgMemberInfo.userAssignedRole === role
-        },
-        isAtLeastRole(orgId: string, role: string): boolean {
-            const orgMemberInfo = orgIdToOrgMemberInfo[orgId]
-            if (orgMemberInfo === undefined) {
-                return false;
-            }
-            return orgMemberInfo.userInheritedRolesPlusCurrentRole.includes(role)
-        },
-        hasPermission(orgId: string, permission: string): boolean {
-            const orgMemberInfo = orgIdToOrgMemberInfo[orgId]
-            if (orgMemberInfo === undefined) {
-                return false;
-            }
-            return orgMemberInfo.userPermissions.includes(permission)
-        },
-        hasAllPermissions(orgId: string, permissions: string[]): boolean {
-            const orgMemberInfo = orgIdToOrgMemberInfo[orgId]
-            if (orgMemberInfo === undefined) {
-                return false;
-            }
-            return permissions.every(permission => orgMemberInfo.userPermissions.includes(permission))
-        },
-        
+        isRole,
+        isAtLeastRole,
+        hasPermission,
+        hasAllPermissions,
+        getAccessHelperWithOrgId,
     }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import { OrgIdToOrgMemberInfo, UserRole } from "./org"
+import { OrgIdToOrgMemberInfo } from "./org"
 import {getOrgHelper, OrgHelper} from "./org_helper";
 
 export type User = {
@@ -131,7 +131,11 @@ export function parseJsonConvertingSnakeToCamel(str: string): AuthenticationInfo
         } else if (key === "url_safe_org_name") {
             this.urlSafeOrgName = value
         } else if (key === "user_role") {
-            this.userRole = toUserRole(value)
+            this.userAssignedRole = value
+        } else if (key === "user_roles") {
+            this.userRoles = value
+        } else if (key === "user_permissions") {
+            this.userPermissions = value
         } else if (key === "access_token") {
             this.accessToken = value
         } else if (key === "expires_at_seconds") {
@@ -155,10 +159,6 @@ export function parseJsonConvertingSnakeToCamel(str: string): AuthenticationInfo
             return value
         }
     })
-}
-
-function toUserRole(userRole: string): UserRole {
-    return UserRole[userRole as keyof typeof UserRole]
 }
 
 function logCorsError() {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,6 @@
 import { OrgIdToOrgMemberInfo } from "./org"
 import {getOrgHelper, OrgHelper} from "./org_helper";
+import {getAccessHelper, AccessHelper} from "./access_helper";
 
 export type User = {
     userId: string
@@ -20,7 +21,8 @@ export type User = {
 export type AuthenticationInfo = {
     accessToken: string
     expiresAtSeconds: number
-    orgHelper: OrgHelper,
+    orgHelper: OrgHelper
+    accessHelper: AccessHelper
 
     /**
      * You should prefer orgHelper to orgIdToOrgMemberInfo.
@@ -29,6 +31,7 @@ export type AuthenticationInfo = {
     orgIdToOrgMemberInfo?: OrgIdToOrgMemberInfo
     user: User
 }
+
 
 export type LogoutResponse = {
     redirect_to: string
@@ -132,8 +135,8 @@ export function parseJsonConvertingSnakeToCamel(str: string): AuthenticationInfo
             this.urlSafeOrgName = value
         } else if (key === "user_role") {
             this.userAssignedRole = value
-        } else if (key === "user_roles") {
-            this.userRoles = value
+        } else if (key === "inherited_user_roles_plus_current_role") {
+            this.userInheritedRolesPlusCurrentRole = value
         } else if (key === "user_permissions") {
             this.userPermissions = value
         } else if (key === "access_token") {
@@ -143,6 +146,7 @@ export function parseJsonConvertingSnakeToCamel(str: string): AuthenticationInfo
         } else if (key === "org_id_to_org_member_info") {
             this.orgIdToOrgMemberInfo = value
             this.orgHelper = getOrgHelper(value)
+            this.accessHelper = getAccessHelper(value)
         } else if (key === "user_id") {
             this.userId = value
         } else if (key === "email_confirmed") {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -115,7 +115,7 @@ test("client parses org information correctly", async () => {
             org_name: "ninetwotwo",
             url_safe_org_name: "ninetwotwo",
             user_role: "Owner",
-            user_roles: ["Owner", "Admin", "Member"],
+            inherited_user_roles_plus_current_role: ["Owner", "Admin", "Member"],
             user_permissions: ["View", "Edit", "Delete", "ManageAccess"],
         },
         "fcdb21f0-b1b6-426f-b83c-6cf4b903d737": {
@@ -123,7 +123,7 @@ test("client parses org information correctly", async () => {
             org_name: "effcdee",
             url_safe_org_name: "effcdee",
             user_role: "Admin",
-            user_roles: ["Admin", "Member"],
+            inherited_user_roles_plus_current_role: ["Admin", "Member"],
             user_permissions: ["View", "Edit", "Delete"],
         },
         "da5903d3-5696-4e4b-920b-bc429b2f75ab": {
@@ -131,7 +131,7 @@ test("client parses org information correctly", async () => {
             org_name: "deeafive",
             url_safe_org_name: "deeafive",
             user_role: "Member",
-            user_roles: ["Member"],
+            inherited_user_roles_plus_current_role: ["Member"],
             user_permissions: ["View"],
         },
     }
@@ -141,7 +141,7 @@ test("client parses org information correctly", async () => {
             orgName: "ninetwotwo",
             urlSafeOrgName: "ninetwotwo",
             userAssignedRole: "Owner",
-            userRoles: ["Owner", "Admin", "Member"],
+            userInheritedRolesPlusCurrentRole: ["Owner", "Admin", "Member"],
             userPermissions: ["View", "Edit", "Delete", "ManageAccess"],
         },
         "fcdb21f0-b1b6-426f-b83c-6cf4b903d737": {
@@ -149,7 +149,7 @@ test("client parses org information correctly", async () => {
             orgName: "effcdee",
             urlSafeOrgName: "effcdee",
             userAssignedRole: "Admin",
-            userRoles: ["Admin", "Member"],
+            userInheritedRolesPlusCurrentRole: ["Admin", "Member"],
             userPermissions: ["View", "Edit", "Delete"],
         },
         "da5903d3-5696-4e4b-920b-bc429b2f75ab": {
@@ -157,7 +157,7 @@ test("client parses org information correctly", async () => {
             orgName: "deeafive",
             urlSafeOrgName: "deeafive",
             userAssignedRole: "Member",
-            userRoles: ["Member"],
+            userInheritedRolesPlusCurrentRole: ["Member"],
             userPermissions: ["View"],
         }
     }
@@ -470,7 +470,7 @@ export type ApiOrgMemberInfo = {
     org_name: string
     url_safe_org_name: string
     user_role: string
-    user_roles: string[]
+    inherited_user_roles_plus_current_role: string[]
     user_permissions: string[]
 }
 export type ApiOrgIdToOrgMemberInfo = {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,7 +3,7 @@
  */
 import { createClient } from "./index"
 import { ok, ResponseStatus, setupMockXMLHttpRequest, UnauthorizedResponse, UnknownErrorResponse } from "./mockxhr.test"
-import { OrgIdToOrgMemberInfo, UserRole } from "./org"
+import { OrgIdToOrgMemberInfo } from "./org"
 
 const INITIAL_TIME_MILLIS = 1619743452595
 const INITIAL_TIME_SECONDS = INITIAL_TIME_MILLIS / 1000
@@ -115,18 +115,24 @@ test("client parses org information correctly", async () => {
             org_name: "ninetwotwo",
             url_safe_org_name: "ninetwotwo",
             user_role: "Owner",
+            user_roles: ["Owner", "Admin", "Member"],
+            user_permissions: ["View", "Edit", "Delete", "ManageAccess"],
         },
         "fcdb21f0-b1b6-426f-b83c-6cf4b903d737": {
             org_id: "fcdb21f0-b1b6-426f-b83c-6cf4b903d737",
             org_name: "effcdee",
             url_safe_org_name: "effcdee",
             user_role: "Admin",
+            user_roles: ["Admin", "Member"],
+            user_permissions: ["View", "Edit", "Delete"],
         },
         "da5903d3-5696-4e4b-920b-bc429b2f75ab": {
             org_id: "da5903d3-5696-4e4b-920b-bc429b2f75ab",
             org_name: "deeafive",
             url_safe_org_name: "deeafive",
             user_role: "Member",
+            user_roles: ["Member"],
+            user_permissions: ["View"],
         },
     }
     const typeScriptOrgIdToOrgMemberInfo: OrgIdToOrgMemberInfo = {
@@ -134,19 +140,25 @@ test("client parses org information correctly", async () => {
             orgId: "922c5c21-be96-484f-9383-ee532dd79d02",
             orgName: "ninetwotwo",
             urlSafeOrgName: "ninetwotwo",
-            userRole: UserRole.Owner,
+            userAssignedRole: "Owner",
+            userRoles: ["Owner", "Admin", "Member"],
+            userPermissions: ["View", "Edit", "Delete", "ManageAccess"],
         },
         "fcdb21f0-b1b6-426f-b83c-6cf4b903d737": {
             orgId: "fcdb21f0-b1b6-426f-b83c-6cf4b903d737",
             orgName: "effcdee",
             urlSafeOrgName: "effcdee",
-            userRole: UserRole.Admin,
+            userAssignedRole: "Admin",
+            userRoles: ["Admin", "Member"],
+            userPermissions: ["View", "Edit", "Delete"],
         },
         "da5903d3-5696-4e4b-920b-bc429b2f75ab": {
             orgId: "da5903d3-5696-4e4b-920b-bc429b2f75ab",
             orgName: "deeafive",
             urlSafeOrgName: "deeafive",
-            userRole: UserRole.Member,
+            userAssignedRole: "Member",
+            userRoles: ["Member"],
+            userPermissions: ["View"],
         }
     }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -470,6 +470,8 @@ export type ApiOrgMemberInfo = {
     org_name: string
     url_safe_org_name: string
     user_role: string
+    user_roles: string[]
+    user_permissions: string[]
 }
 export type ApiOrgIdToOrgMemberInfo = {
     [org_id: string]: ApiOrgMemberInfo

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 export type { AuthenticationInfo, User } from "./api"
 export { createClient } from "./client"
 export type { IAuthClient, IAuthOptions, RedirectToSignupOptions, RedirectToLoginOptions } from "./client"
-export { UserRole } from "./org"
 export type { OrgIdToOrgMemberInfo, OrgMemberInfo } from "./org"
 export type { OrgHelper } from "./org_helper"

--- a/src/org.ts
+++ b/src/org.ts
@@ -2,14 +2,10 @@ export type OrgMemberInfo = {
     orgId: string
     orgName: string
     urlSafeOrgName: string
-    userRole: UserRole
+    userAssignedRole: string
+    userRoles: string[]
+    userPermissions: string[]
 }
 export type OrgIdToOrgMemberInfo = {
     [orgId: string]: OrgMemberInfo
-}
-
-export enum UserRole {
-    Member = 0,
-    Admin = 1,
-    Owner = 2,
 }

--- a/src/org.ts
+++ b/src/org.ts
@@ -3,7 +3,7 @@ export type OrgMemberInfo = {
     orgName: string
     urlSafeOrgName: string
     userAssignedRole: string
-    userRoles: string[]
+    userInheritedRolesPlusCurrentRole: string[]
     userPermissions: string[]
 }
 export type OrgIdToOrgMemberInfo = {

--- a/src/org_helper.test.js
+++ b/src/org_helper.test.js
@@ -78,17 +78,14 @@ function createOrg() {
         orgId: uuidv4(),
         orgName,
         urlSafeOrgName,
-        userRole: choose(["Owner", "Admin", "Member"]),
+        userAssignedRole: "Admin",
+        userRoles: ["Admin", "Member"],
+        userPermissions: [],
     }
 }
 
 function randomString() {
     return (Math.random() + 1).toString(36).substring(3)
-}
-
-function choose(choices) {
-    const index = Math.floor(Math.random() * choices.length)
-    return choices[index]
 }
 
 // https://stackoverflow.com/questions/8024149/is-it-possible-to-get-the-non-enumerable-inherited-property-names-of-an-object

--- a/src/org_helper.test.js
+++ b/src/org_helper.test.js
@@ -3,6 +3,7 @@
  */
 import { v4 as uuidv4 } from "uuid"
 import { getOrgHelper } from "./org_helper"
+import { createOrgs, createOrgIdToOrgMemberInfo, getAllProperties } from "./test_helper"
 
 beforeEach(() => {
     const localStorageMock = (function () {
@@ -54,51 +55,3 @@ it("getter methods work", async () => {
         expect(orgHelper.getOrgByName(uuidv4())).toBeFalsy()
     }
 })
-
-function createOrgIdToOrgMemberInfo(orgs) {
-    let orgIdToOrgMemberInfo = {}
-    for (let org of orgs) {
-        orgIdToOrgMemberInfo[org.orgId] = org
-    }
-    return orgIdToOrgMemberInfo
-}
-
-function createOrgs(numOrgs) {
-    let orgs = []
-    for (let i = 0; i < numOrgs; i++) {
-        orgs.push(createOrg())
-    }
-    return orgs
-}
-
-function createOrg() {
-    const orgName = randomString()
-    const urlSafeOrgName = orgName.toLowerCase()
-    return {
-        orgId: uuidv4(),
-        orgName,
-        urlSafeOrgName,
-        userAssignedRole: "Admin",
-        userRoles: ["Admin", "Member"],
-        userPermissions: [],
-    }
-}
-
-function randomString() {
-    return (Math.random() + 1).toString(36).substring(3)
-}
-
-// https://stackoverflow.com/questions/8024149/is-it-possible-to-get-the-non-enumerable-inherited-property-names-of-an-object
-function getAllProperties(obj) {
-    let allProps = [],
-        curr = obj
-    do {
-        const props = Object.getOwnPropertyNames(curr)
-        props.forEach(function (prop) {
-            if (allProps.indexOf(prop) === -1) {
-                allProps.push(prop)
-            }
-        })
-    } while ((curr = Object.getPrototypeOf(curr)))
-    return allProps
-}

--- a/src/test_helper.js
+++ b/src/test_helper.js
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+import { v4 as uuidv4 } from "uuid"
+
+export function createOrgIdToOrgMemberInfo(orgs) {
+    let orgIdToOrgMemberInfo = {}
+    for (let org of orgs) {
+        orgIdToOrgMemberInfo[org.orgId] = org
+    }
+    return orgIdToOrgMemberInfo
+}
+
+export function createOrgs(numOrgs) {
+    let orgs = []
+    for (let i = 0; i < numOrgs; i++) {
+        orgs.push(createOrg())
+    }
+    return orgs
+}
+
+export function createOrg() {
+    const orgName = randomString()
+    const urlSafeOrgName = orgName.toLowerCase()
+    return {
+        orgId: uuidv4(),
+        orgName,
+        urlSafeOrgName,
+        userAssignedRole: "Admin",
+        userInheritedRolesPlusCurrentRole: ["Admin", "Member"],
+        userPermissions: ["read", "write"],
+    }
+}
+
+function randomString() {
+    return (Math.random() + 1).toString(36).substring(3)
+}
+
+// https://stackoverflow.com/questions/8024149/is-it-possible-to-get-the-non-enumerable-inherited-property-names-of-an-object
+export function getAllProperties(obj) {
+    let allProps = [],
+        curr = obj
+    do {
+        const props = Object.getOwnPropertyNames(curr)
+        props.forEach(function (prop) {
+            if (allProps.indexOf(prop) === -1) {
+                allProps.push(prop)
+            }
+        })
+    } while ((curr = Object.getPrototypeOf(curr)))
+    return allProps
+}


### PR DESCRIPTION
Roles are now customizable in the backend, and this codebase handles that. A user still has a single role, but now we give a list of all roles that role "inherits" from.

The old attribute userRole is renamed userAssignedRole. It's now a straight string instead of an enum.

There are two new attributes to look at:

- userRoles is a list of all roles that this user "inherits". Instead of checking roles with < and >, you should check for the existence of the role in this list.
- userPermissions is a list of all permissions this user has. These are the four hardcoded permissions, e.g. SAML, deleting users, etc.