### PR TITLE
multi role support

### DIFF
--- a/src/access_helper.ts
+++ b/src/access_helper.ts
@@ -1,4 +1,4 @@
-import {OrgIdToOrgMemberInfo} from "./org";
+import {OrgIdToOrgMemberInfo, OrgRoleStructure} from "./org";
 
 export type AccessHelper = {
     isRole: (orgId: string, role: string) => boolean
@@ -23,7 +23,11 @@ export function getAccessHelper(
         if (orgMemberInfo === undefined) {
             return false;
         }
-        return orgMemberInfo.userAssignedRole === role
+        if (orgMemberInfo.orgRoleStructure === OrgRoleStructure.MultiRole) {
+            return orgMemberInfo.userAssignedRole === role || orgMemberInfo.userAssignedAdditionalRoles.includes(role)
+        } else {
+            return orgMemberInfo.userAssignedRole === role
+        }
     }
     
     function isAtLeastRole(orgId: string, role: string): boolean {
@@ -31,7 +35,11 @@ export function getAccessHelper(
         if (orgMemberInfo === undefined) {
             return false;
         }
-        return orgMemberInfo.userInheritedRolesPlusCurrentRole.includes(role)
+        if (orgMemberInfo.orgRoleStructure === OrgRoleStructure.MultiRole) {
+            return orgMemberInfo.userAssignedRole === role || orgMemberInfo.userAssignedAdditionalRoles.includes(role)
+        } else {
+            return orgMemberInfo.userInheritedRolesPlusCurrentRole.includes(role)
+        }
     }
 
     function hasPermission(orgId: string, permission: string): boolean {

--- a/src/api.ts
+++ b/src/api.ts
@@ -176,6 +176,10 @@ export function parseJsonConvertingSnakeToCamel(str: string): AuthenticationInfo
             this.legacyUserId = value
         } else if (key === "impersonator_user") {
             this.impersonatorUserId = value
+        } else if (key === "org_role_structure") {
+            this.orgRoleStructure = value
+        } else if (key === "additional_roles") {
+            this.userAssignedAdditionalRoles = value
         } else {
             return value
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export type {
 } from "./client"
 export { ACTIVE_ORG_ID_COOKIE_NAME } from "./cookies"
 export { getActiveOrgId, setActiveOrgId } from "./org"
-export type { OrgIdToOrgMemberInfo, OrgMemberInfo } from "./org"
+export type { OrgIdToOrgMemberInfo, OrgMemberInfo, OrgRoleStructure } from "./org"
 export type { OrgHelper } from "./org_helper"
 export { OrgMemberInfoClass, UserClass } from "./user"
 export type { OrgIdToOrgMemberInfoClass, UserFields, UserProperties } from "./user"

--- a/src/org.ts
+++ b/src/org.ts
@@ -6,12 +6,19 @@ export type OrgMemberInfo = {
     orgName: string
     orgMetadata: { [key: string]: any }
     urlSafeOrgName: string
+    orgRoleStructure: OrgRoleStructure
     userAssignedRole: string
     userInheritedRolesPlusCurrentRole: string[]
     userPermissions: string[]
+    userAssignedAdditionalRoles: string[]
 }
 export type OrgIdToOrgMemberInfo = {
     [orgId: string]: OrgMemberInfo
+}
+
+export enum OrgRoleStructure {
+    SingleRole = "single_role_in_hierarchy",
+    MultiRole = "multi_role",
 }
 
 export const setActiveOrgId = (orgId: string) => {

--- a/src/tests/access_helper.test.js
+++ b/src/tests/access_helper.test.js
@@ -70,3 +70,48 @@ it("accessHelper validate wrapper methods work", async () => {
     expect(accessHelperWrapper.hasAllPermissions(["read", "write", "delete"])).toBeFalsy()
     expect(accessHelperWrapperBad.isRole("Admin")).toBeFalsy()
 })
+
+// Multi role tests
+it("accessHelper validate methods work with multi role", async () => {
+    const orgs = createOrgs(1, true)
+    const orgId = orgs[0].orgId
+    const fakeOrgId = "fakeOrgId"
+    const orgIdToOrgMemberInfo = createOrgIdToOrgMemberInfo(orgs)
+
+    const accessHelper = getAccessHelper(orgIdToOrgMemberInfo)
+
+    // org has the roles of "Role A", "Role B", and "Role C" in orgId
+    expect(accessHelper.isRole(orgId, "")).toBeFalsy()
+    expect(accessHelper.isRole(orgId, "Role D")).toBeFalsy()
+    expect(accessHelper.isRole(orgId, "Role A")).toBeTruthy()
+    expect(accessHelper.isRole(fakeOrgId, "Role A")).toBeFalsy()
+    expect(accessHelper.isRole(orgId, "Role B")).toBeTruthy()
+    expect(accessHelper.isRole(orgId, "Role C")).toBeTruthy()
+    
+    // isAtLeastRole should work the same as isRole for multi role
+    expect(accessHelper.isAtLeastRole(orgId, "")).toBeFalsy()
+    expect(accessHelper.isAtLeastRole(orgId, "Role D")).toBeFalsy()
+    expect(accessHelper.isAtLeastRole(orgId, "Role A")).toBeTruthy()
+    expect(accessHelper.isAtLeastRole(fakeOrgId, "Role A")).toBeFalsy()
+    expect(accessHelper.isAtLeastRole(orgId, "Role B")).toBeTruthy()
+    expect(accessHelper.isAtLeastRole(orgId, "Role C")).toBeTruthy()
+
+    // org has the permissions "read" and "write"
+    expect(accessHelper.hasPermission(orgId, "")).toBeFalsy()
+    expect(accessHelper.hasPermission(orgId, "read")).toBeTruthy()
+    expect(accessHelper.hasPermission(fakeOrgId, "read")).toBeFalsy()
+    expect(accessHelper.hasPermission(orgId, "write")).toBeTruthy()
+    expect(accessHelper.hasPermission(orgId, "delete")).toBeFalsy()
+
+    // org has the permissions "read" and "write"
+    expect(accessHelper.hasAllPermissions(orgId, [])).toBeTruthy()
+    expect(accessHelper.hasAllPermissions(orgId, [""])).toBeFalsy()
+    expect(accessHelper.hasAllPermissions(orgId, ["read"])).toBeTruthy()
+    expect(accessHelper.hasAllPermissions(fakeOrgId, ["read"])).toBeFalsy()
+    expect(accessHelper.hasAllPermissions(orgId, ["write"])).toBeTruthy()
+    expect(accessHelper.hasAllPermissions(orgId, ["delete"])).toBeFalsy()
+    expect(accessHelper.hasAllPermissions(orgId, ["read", "write"])).toBeTruthy()
+    expect(accessHelper.hasAllPermissions(orgId, ["read", "delete"])).toBeFalsy()
+    expect(accessHelper.hasAllPermissions(orgId, ["write", "delete"])).toBeFalsy()
+    expect(accessHelper.hasAllPermissions(orgId, ["read", "write", "delete"])).toBeFalsy()
+})

--- a/src/tests/test_helper.js
+++ b/src/tests/test_helper.js
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { v4 as uuidv4 } from "uuid"
+import { OrgRoleStructure } from "../org"
 
 export function createOrgIdToOrgMemberInfo(orgs) {
     let orgIdToOrgMemberInfo = {}
@@ -11,10 +12,14 @@ export function createOrgIdToOrgMemberInfo(orgs) {
     return orgIdToOrgMemberInfo
 }
 
-export function createOrgs(numOrgs) {
+export function createOrgs(numOrgs, multiRole = false) {
     let orgs = []
     for (let i = 0; i < numOrgs; i++) {
-        orgs.push(createOrg())
+        if (multiRole) {
+            orgs.push(createOrgWithMultiRoles())
+        } else {
+            orgs.push(createOrg())
+        }
     }
     return orgs
 }
@@ -32,6 +37,24 @@ export function createOrg() {
         userAssignedRole: "Admin",
         userInheritedRolesPlusCurrentRole: ["Admin", "Member"],
         userPermissions: ["read", "write"],
+    }
+}
+
+export function createOrgWithMultiRoles() {
+    const orgName = randomString()
+    const urlSafeOrgName = orgName.toLowerCase()
+    return {
+        orgId: uuidv4(),
+        orgName,
+        orgMetadata: {
+            hello: "world",
+        },
+        urlSafeOrgName,
+        orgRoleStructure: OrgRoleStructure.MultiRole,
+        userAssignedRole: "Role A",
+        userInheritedRolesPlusCurrentRole: ["Role A"],
+        userPermissions: ["read", "write"],
+        userAssignedAdditionalRoles: ["Role B", "Role C"],
     }
 }
 

--- a/src/user.test.ts
+++ b/src/user.test.ts
@@ -1,3 +1,4 @@
+import { OrgRoleStructure } from "./org"
 import { UserClass, OrgMemberInfoClass } from "./user"
 
 const mockUserOrgInfo = new OrgMemberInfoClass(
@@ -96,6 +97,113 @@ describe("User", () => {
         })
         it("should parse a org member info from JSON string", () => {
             expect(OrgMemberInfoClass.fromJSON(JSON.stringify(mockUserOrgInfo))).toEqual(mockUserOrgInfo)
+            expect(() => OrgMemberInfoClass.fromJSON("invalid json")).toThrowError()
+        })
+    })
+})
+
+const mockUserOrgInfoMultiRole = new OrgMemberInfoClass(
+    "mockOrgId",
+    "Mock Org Name",
+    {},
+    "mock-org-name",
+    "Role A",
+    ["Role A"],
+    ["user::create", "user::delete"],
+    OrgRoleStructure.MultiRole,
+    ["Role B", "Role C"],
+)
+
+const mockUserMultiRole = new UserClass(
+    {
+        userId: "userId",
+        email: "email",
+        createdAt: 12345678,
+        firstName: "firstName",
+        lastName: "lastName",
+        username: "username",
+        legacyUserId: "legacyUserId",
+        impersonatorUserId: "impersonatorUserId",
+        properties: {
+            property: "value",
+        },
+    },
+    {
+        mockOrgId: mockUserOrgInfoMultiRole,
+    }
+)
+
+describe("User multi-role", () => {
+    describe("User Class multi-role", () => {
+        it("should get an org", () => {
+            expect(mockUserMultiRole.getOrg("mockOrgId")).toEqual(mockUserOrgInfoMultiRole)
+            expect(mockUserMultiRole.getOrg("mockOrgId2")).toBeUndefined()
+        })
+        it("should get an org by name", () => {
+            expect(mockUserMultiRole.getOrgByName("Mock Org Name")).toEqual(mockUserOrgInfoMultiRole)
+            expect(mockUserMultiRole.getOrgByName("Mock Org Name 2")).toBeUndefined()
+        })
+        it("should get a user property", () => {
+            expect(mockUserMultiRole.getUserProperty("property")).toEqual("value")
+            expect(mockUserMultiRole.getUserProperty("property2")).toBeUndefined()
+        })
+        it("should get all orgs", () => {
+            expect(mockUserMultiRole.getOrgs()).toEqual([mockUserOrgInfoMultiRole])
+        })
+        it("should ensure the user is a certain role", () => {
+            expect(mockUserMultiRole.isRole("mockOrgId", "Role A")).toEqual(true)
+            expect(mockUserMultiRole.isRole("mockOrgId", "Role B")).toEqual(true)
+            expect(mockUserMultiRole.isRole("mockOrgId", "Role C")).toEqual(true)
+            expect(mockUserMultiRole.isRole("mockOrgId", "Role D")).toEqual(false)
+            expect(mockUserMultiRole.isRole("mockOrgId2", "Role A")).toEqual(false)
+        })
+        it("should ensure the user is at least a certain role", () => {
+            expect(mockUserMultiRole.isAtLeastRole("mockOrgId", "Role A")).toEqual(true)
+            expect(mockUserMultiRole.isAtLeastRole("mockOrgId", "Role B")).toEqual(true)
+            expect(mockUserMultiRole.isAtLeastRole("mockOrgId", "Role C")).toEqual(true)
+            expect(mockUserMultiRole.isAtLeastRole("mockOrgId", "Role D")).toEqual(false)
+            expect(mockUserMultiRole.isAtLeastRole("mockOrgId2", "Role A")).toEqual(false)
+        })
+        it("should ensure the user has a permission", () => {
+            expect(mockUserMultiRole.hasPermission("mockOrgId", "user::create")).toEqual(true)
+            expect(mockUserMultiRole.hasPermission("mockOrgId", "user::delete")).toEqual(true)
+            expect(mockUserMultiRole.hasPermission("mockOrgId", "user::update")).toEqual(false)
+            expect(mockUserMultiRole.hasPermission("mockOrgId2", "user::create")).toEqual(false)
+        })
+        it("should ensure the user has all permissions", () => {
+            expect(mockUserMultiRole.hasAllPermissions("mockOrgId", ["user::create", "user::delete"])).toEqual(true)
+            expect(mockUserMultiRole.hasAllPermissions("mockOrgId", ["user::create", "user::update"])).toEqual(false)
+            expect(mockUserMultiRole.hasAllPermissions("mockOrgId2", ["user::create", "user::delete"])).toEqual(false)
+        })
+        it("should parse a user from JSON string", () => {
+            expect(UserClass.fromJSON(JSON.stringify(mockUser))).toEqual(mockUser)
+            expect(() => UserClass.fromJSON("invalid json")).toThrowError()
+        })
+    })
+    describe("UserOrgInfo Class multi-role", () => {
+        it("should validate a role", () => {
+            expect(mockUserOrgInfoMultiRole.isRole("Role A")).toEqual(true)
+            expect(mockUserOrgInfoMultiRole.isRole("Role B")).toEqual(true)
+            expect(mockUserOrgInfoMultiRole.isRole("Role C")).toEqual(true)
+            expect(mockUserOrgInfoMultiRole.isRole("Role D")).toEqual(false)
+        })
+        it("should validate a role is at least a certain role", () => {
+            expect(mockUserOrgInfoMultiRole.isAtLeastRole("Role A")).toEqual(true)
+            expect(mockUserOrgInfoMultiRole.isAtLeastRole("Role B")).toEqual(true)
+            expect(mockUserOrgInfoMultiRole.isAtLeastRole("Role C")).toEqual(true)
+            expect(mockUserOrgInfoMultiRole.isAtLeastRole("Role D")).toEqual(false)
+        })
+        it("should validate a permission", () => {
+            expect(mockUserOrgInfoMultiRole.hasPermission("user::create")).toEqual(true)
+            expect(mockUserOrgInfoMultiRole.hasPermission("user::delete")).toEqual(true)
+            expect(mockUserOrgInfoMultiRole.hasPermission("user::update")).toEqual(false)
+        })
+        it("should validate all permissions", () => {
+            expect(mockUserOrgInfoMultiRole.hasAllPermissions(["user::create", "user::delete"])).toEqual(true)
+            expect(mockUserOrgInfoMultiRole.hasAllPermissions(["user::create", "user::update"])).toEqual(false)
+        })
+        it("should parse a org member info from JSON string", () => {
+            expect(OrgMemberInfoClass.fromJSON(JSON.stringify(mockUserOrgInfoMultiRole))).toEqual(mockUserOrgInfoMultiRole)
             expect(() => OrgMemberInfoClass.fromJSON("invalid json")).toThrowError()
         })
     })

--- a/src/user.ts
+++ b/src/user.ts
@@ -1,4 +1,4 @@
-import { OrgIdToOrgMemberInfo } from "./org"
+import { OrgIdToOrgMemberInfo, OrgRoleStructure } from "./org"
 
 export type UserProperties = { [key: string]: unknown }
 
@@ -179,10 +179,12 @@ export class OrgMemberInfoClass {
     public orgName: string
     public orgMetadata: { [key: string]: any }
     public urlSafeOrgName: string
+    public orgRoleStructure: OrgRoleStructure
 
     public userAssignedRole: string
     public userInheritedRolesPlusCurrentRole: string[]
     public userPermissions: string[]
+    public userAssignedAdditionalRoles: string[]
 
     constructor(
         orgId: string,
@@ -191,25 +193,37 @@ export class OrgMemberInfoClass {
         urlSafeOrgName: string,
         userAssignedRole: string,
         userInheritedRolesPlusCurrentRole: string[],
-        userPermissions: string[]
+        userPermissions: string[],
+        orgRoleStructure?: OrgRoleStructure,
+        userAssignedAdditionalRoles?: string[]
     ) {
         this.orgId = orgId
         this.orgName = orgName
         this.orgMetadata = orgMetadata
         this.urlSafeOrgName = urlSafeOrgName
+        this.orgRoleStructure = orgRoleStructure ?? OrgRoleStructure.SingleRole
 
         this.userAssignedRole = userAssignedRole
         this.userInheritedRolesPlusCurrentRole = userInheritedRolesPlusCurrentRole
         this.userPermissions = userPermissions
+        this.userAssignedAdditionalRoles = userAssignedAdditionalRoles ?? []
     }
 
     // validation methods
     public isRole(role: string): boolean {
-        return this.userAssignedRole === role
+        if (this.orgRoleStructure === OrgRoleStructure.MultiRole) {
+            return this.userAssignedRole === role || this.userAssignedAdditionalRoles.includes(role)
+        } else {
+            return this.userAssignedRole === role
+        }
     }
 
     public isAtLeastRole(role: string): boolean {
-        return this.userInheritedRolesPlusCurrentRole.includes(role)
+        if (this.orgRoleStructure === OrgRoleStructure.MultiRole) {
+            return this.userAssignedRole === role || this.userAssignedAdditionalRoles.includes(role)
+        } else {
+            return this.userInheritedRolesPlusCurrentRole.includes(role)
+        }
     }
 
     public hasPermission(permission: string): boolean {
@@ -230,7 +244,9 @@ export class OrgMemberInfoClass {
                 obj.urlSafeOrgName,
                 obj.userAssignedRole,
                 obj.userInheritedRolesPlusCurrentRole,
-                obj.userPermissions
+                obj.userPermissions,
+                obj.orgRoleStructure,
+                obj.userAssignedAdditionalRoles
             )
         } catch (e) {
             console.error(
@@ -257,7 +273,9 @@ export function convertOrgIdToOrgMemberInfo(
             orgMemberInfo.urlSafeOrgName,
             orgMemberInfo.userAssignedRole,
             orgMemberInfo.userInheritedRolesPlusCurrentRole,
-            orgMemberInfo.userPermissions
+            orgMemberInfo.userPermissions,
+            orgMemberInfo.orgRoleStructure,
+            orgMemberInfo.userAssignedAdditionalRoles
         )
     }
     return orgIdToUserOrgInfo


### PR DESCRIPTION
[Notion](https://www.notion.so/2023-03-17-Multiple-Roles-Per-User-7e67773661ba4a05877162cac28ab1f6)
This adds support for a user to have multiple role assigned to them for a given org membership.

## Tests
- unit tests including new ones for multi role isRole and isAtLeastRole
- smoke tested with react example app that data is populating correctly in the UserClass