### PR TITLE
[FEAT] Active Org Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@propelauth/javascript",
-  "version": "2.0.13",
+  "version": "2.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@propelauth/javascript",
-      "version": "2.0.13",
+      "version": "2.0.17",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.13.16",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "type": "git",
         "url": "https://github.com/PropelAuth/javascript"
     },
-    "version": "2.0.16",
+    "version": "2.0.17",
     "keywords": [
         "auth",
         "user",

--- a/src/api.ts
+++ b/src/api.ts
@@ -68,6 +68,12 @@ export function fetchAuthenticationInfo(authUrl: string, activeOrgId?: string): 
         },
     }).then((res) => {
         if (res.status === 401) {
+            if (!!activeOrgId && res.statusText === "user not in org") {
+                return Promise.reject({
+                    status: res.status,
+                    message: res.statusText,
+                })
+            }
             return null
         } else if (res.status === 0) {
             logCorsError()

--- a/src/api.ts
+++ b/src/api.ts
@@ -51,8 +51,16 @@ export type LogoutResponse = {
     redirect_to: string
 }
 
-export function fetchAuthenticationInfo(authUrl: string): Promise<AuthenticationInfo | null> {
-    return fetch(`${authUrl}/api/v1/refresh_token`, {
+export function fetchAuthenticationInfo(authUrl: string, activeOrgId?: string): Promise<AuthenticationInfo | null> {
+    const queryParams = new URLSearchParams()
+    if (activeOrgId) {
+        queryParams.append("active_org_id", activeOrgId)
+    }
+    let path = `${authUrl}/api/v1/refresh_token`
+    if (queryParams.toString()) {
+        path += `?${queryParams.toString()}`
+    }
+    return fetch(path, {
         method: "GET",
         credentials: "include",
         headers: {

--- a/src/api.ts
+++ b/src/api.ts
@@ -68,12 +68,6 @@ export function fetchAuthenticationInfo(authUrl: string, activeOrgId?: string): 
         },
     }).then((res) => {
         if (res.status === 401) {
-            if (!!activeOrgId && res.statusText === "user not in org") {
-                return Promise.reject({
-                    status: res.status,
-                    message: res.statusText,
-                })
-            }
             return null
         } else if (res.status === 0) {
             logCorsError()

--- a/src/client.ts
+++ b/src/client.ts
@@ -106,7 +106,7 @@ export interface IAuthClient {
     /**
      * Gets an access token for a specific organization, known as an Active Org.
      */
-    getAccessTokenForActiveOrg(orgId: string): Promise<AccessTokenForActiveOrg>
+    getAccessTokenForOrg(orgId: string): Promise<AccessTokenForActiveOrg>
 
     /**
      * Redirects the user to the signup page.
@@ -489,7 +489,7 @@ export function createClient(authOptions: IAuthOptions): IAuthClient {
             }
         },
 
-        async getAccessTokenForActiveOrg(orgId: string): Promise<AccessTokenForActiveOrg> {
+        async getAccessTokenForOrg(orgId: string): Promise<AccessTokenForActiveOrg> {
             // First, check if there is a valid access token for the org ID in the
             // valid time frame.
             const currentTimeSecs = currentTimeSeconds()

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export type { AccessHelper, AccessHelperWithOrg } from "./access_helper"
 export type { AuthenticationInfo, User } from "./api"
 export { createClient } from "./client"
 export type {
+    AccessTokenForActiveOrg,
     IAuthClient,
     IAuthOptions,
     RedirectToAccountOptions,


### PR DESCRIPTION
## Background

This PR introduces the concept of "Active Orgs" -- it may be the case that when a user is in many orgs, the access token becomes too big with the org information. As such, we should allow a way for the user to get an access token specific for their org. This adds a function to fetch this active org access token, as well as handles some retry/time expiration logic.

## Video
https://www.loom.com/share/6acc5295622a40daaaca5d4fa1a1be58