### PR TITLE
Add support for legacy org id

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -182,6 +182,8 @@ export function parseJsonConvertingSnakeToCamel(str: string): AuthenticationInfo
             this.lastActiveAt = value
         } else if (key === "legacy_user_id") {
             this.legacyUserId = value
+        } else if (key === "legacy_org_id") {
+            this.legacyOrgId = value
         } else if (key === "impersonator_user") {
             this.impersonatorUserId = value
         } else if (key === "org_role_structure") {

--- a/src/org.ts
+++ b/src/org.ts
@@ -11,7 +11,7 @@ export type OrgMemberInfo = {
     userInheritedRolesPlusCurrentRole: string[]
     userPermissions: string[]
     userAssignedAdditionalRoles: string[]
-    legacyOrgId: string
+    legacyOrgId?: string
 }
 export type OrgIdToOrgMemberInfo = {
     [orgId: string]: OrgMemberInfo

--- a/src/org.ts
+++ b/src/org.ts
@@ -11,6 +11,7 @@ export type OrgMemberInfo = {
     userInheritedRolesPlusCurrentRole: string[]
     userPermissions: string[]
     userAssignedAdditionalRoles: string[]
+    legacyOrgId: string
 }
 export type OrgIdToOrgMemberInfo = {
     [orgId: string]: OrgMemberInfo

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -112,7 +112,7 @@ test("client parses user correctly", async () => {
 
 test("client parses org information correctly", async () => {
     const expiresAtSeconds = INITIAL_TIME_SECONDS + 60 * 30
-    const apiOrgIdToOrgMemberInfo = {
+    const apiOrgIdToOrgMemberInfo: ApiOrgIdToOrgMemberInfo = {
         "922c5c21-be96-484f-9383-ee532dd79d02": {
             org_id: "922c5c21-be96-484f-9383-ee532dd79d02",
             org_name: "ninetwotwo",
@@ -120,6 +120,7 @@ test("client parses org information correctly", async () => {
             user_role: "Owner",
             inherited_user_roles_plus_current_role: ["Owner", "Admin", "Member"],
             user_permissions: ["View", "Edit", "Delete", "ManageAccess"],
+            legacy_org_id: "ce126279-48a2-4fc4-a9e5-da62a33d1b11"
         },
         "fcdb21f0-b1b6-426f-b83c-6cf4b903d737": {
             org_id: "fcdb21f0-b1b6-426f-b83c-6cf4b903d737",
@@ -146,6 +147,7 @@ test("client parses org information correctly", async () => {
             userAssignedRole: "Owner",
             userInheritedRolesPlusCurrentRole: ["Owner", "Admin", "Member"],
             userPermissions: ["View", "Edit", "Delete", "ManageAccess"],
+            legacyOrgId: "ce126279-48a2-4fc4-a9e5-da62a33d1b11"
         },
         "fcdb21f0-b1b6-426f-b83c-6cf4b903d737": {
             orgId: "fcdb21f0-b1b6-426f-b83c-6cf4b903d737",
@@ -457,6 +459,7 @@ export type ApiOrgMemberInfo = {
     user_role: string
     inherited_user_roles_plus_current_role: string[]
     user_permissions: string[]
+    legacy_org_id?: string
 }
 export type ApiOrgIdToOrgMemberInfo = {
     [org_id: string]: ApiOrgMemberInfo

--- a/src/user.test.ts
+++ b/src/user.test.ts
@@ -8,7 +8,8 @@ const mockUserOrgInfo = new OrgMemberInfoClass(
     "mock-org-name",
     "Admin",
     ["Admin", "Member"],
-    ["user::create", "user::delete"]
+    ["user::create", "user::delete"],
+    "mockLegacyOrgId"
 )
 
 const mockUser = new UserClass(
@@ -110,6 +111,7 @@ const mockUserOrgInfoMultiRole = new OrgMemberInfoClass(
     "Role A",
     ["Role A"],
     ["user::create", "user::delete"],
+    "mockLegacyOrgId",
     OrgRoleStructure.MultiRole,
     ["Role B", "Role C"],
 )

--- a/src/user.ts
+++ b/src/user.ts
@@ -177,6 +177,7 @@ export interface OrgIdToOrgMemberInfoClass {
 export class OrgMemberInfoClass {
     public orgId: string
     public orgName: string
+    public legacyOrgId?: string
     public orgMetadata: { [key: string]: any }
     public urlSafeOrgName: string
     public orgRoleStructure: OrgRoleStructure
@@ -194,11 +195,13 @@ export class OrgMemberInfoClass {
         userAssignedRole: string,
         userInheritedRolesPlusCurrentRole: string[],
         userPermissions: string[],
+        legacyOrgId?: string,
         orgRoleStructure?: OrgRoleStructure,
         userAssignedAdditionalRoles?: string[]
     ) {
         this.orgId = orgId
         this.orgName = orgName
+        this.legacyOrgId = legacyOrgId
         this.orgMetadata = orgMetadata
         this.urlSafeOrgName = urlSafeOrgName
         this.orgRoleStructure = orgRoleStructure ?? OrgRoleStructure.SingleRole
@@ -245,6 +248,7 @@ export class OrgMemberInfoClass {
                 obj.userAssignedRole,
                 obj.userInheritedRolesPlusCurrentRole,
                 obj.userPermissions,
+                obj.legacyOrgId,
                 obj.orgRoleStructure,
                 obj.userAssignedAdditionalRoles
             )
@@ -274,6 +278,7 @@ export function convertOrgIdToOrgMemberInfo(
             orgMemberInfo.userAssignedRole,
             orgMemberInfo.userInheritedRolesPlusCurrentRole,
             orgMemberInfo.userPermissions,
+            orgMemberInfo.legacyOrgId,
             orgMemberInfo.orgRoleStructure,
             orgMemberInfo.userAssignedAdditionalRoles
         )


### PR DESCRIPTION
This PR adds support for the legacy_org_id which then can also be accessed and used in the front-end similar to how it's currently supported in the node library by PropelAuth.